### PR TITLE
Feat: 하단 네비게이션 바 구현

### DIFF
--- a/lib/core/app.dart
+++ b/lib/core/app.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:look_talk/core/router/router.dart';
+import 'package:look_talk/core/theme/app_theme.dart';
+
+import '../ui/common/const/colors.dart';
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: 'LookTalk',
+      routerConfig: router,
+      debugShowCheckedModeBanner: false,
+      color: AppColors.white,
+      theme: AppTheme.light(),
+    );
+  }
+}

--- a/lib/core/extension/text_style_extension.dart
+++ b/lib/core/extension/text_style_extension.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+// text style 지정할 때
+// 원래 Theme.of(context).textTheme.bodySmall 이렇게 해서 font를 사용해야하는데
+// extension 을 사용하면 context.caption 이렇게 간단하게 사용 가능합니다!!!
+
+// 사용 예시
+// Text('예시', style: context.caption)
+
+extension TextStyleExtension on BuildContext {
+  TextStyle get h1 => Theme.of(this).textTheme.headlineLarge!;
+  TextStyle get body => Theme.of(this).textTheme.bodyMedium!;
+  TextStyle get bodyBold => Theme.of(this).textTheme.bodyLarge!;
+  TextStyle get caption => Theme.of(this).textTheme.bodySmall!;
+}

--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -1,0 +1,24 @@
+import 'package:go_router/go_router.dart';
+import 'package:look_talk/ui/main/bottom_nav_screen.dart';
+import 'package:look_talk/ui/main/category/category_screen.dart';
+import 'package:look_talk/ui/main/community/community_screen.dart';
+import 'package:look_talk/ui/main/home/home_screen.dart';
+import 'package:look_talk/ui/main/mypage/mypage_screen.dart';
+import 'package:look_talk/ui/main/wishlist/wishlist_screen.dart';
+
+final GoRouter router = GoRouter(
+  initialLocation: '/home',
+  routes: [
+    ShellRoute(builder: (context, state, child){
+      return BottomNavScreen(child: child);
+    },
+      routes: [
+        GoRoute(path: '/home', builder: (context, state) => const HomeScreen()),
+        GoRoute(path: '/category', builder: (context, state) => const CategoryScreen()),
+        GoRoute(path: '/community', builder: (context, state) => const CommunityScreen()),
+        GoRoute(path: '/wishlist', builder: (context, state) => const WishlistScreen()),
+        GoRoute(path: '/mypage', builder: (context, state) => const MyPageScreen()),
+      ]
+    ),
+  ]
+);

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import '../../ui/common/const/colors.dart';
+import '../../ui/common/const/text_sizes.dart';
+
+class AppTheme {
+  static ThemeData light() {
+    return ThemeData(
+      fontFamily: 'NanumSquareRound',
+      textTheme: const TextTheme(
+
+        headlineLarge: TextStyle(
+          fontSize: 20,
+          fontWeight: FontWeight.w800, // extra bold
+        ),
+
+        bodyLarge: TextStyle(
+          fontSize: 15,
+          fontWeight: FontWeight.w700, // bold
+        ),
+
+        bodyMedium: TextStyle(
+          fontSize: 15,
+          fontWeight: FontWeight.w400, // regular
+        ),
+
+        bodySmall: TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.w300, // light
+        ),
+
+      ),
+      colorScheme: ColorScheme.fromSeed(seedColor: AppColors.primary),
+      useMaterial3: true,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,55 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:look_talk/ui/common/const/text_sizes.dart';
-import 'package:look_talk/ui/main/home/home_screen.dart';
+
+import 'core/app.dart';
 
 void main() {
   runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'LookTalk',
-      theme: ThemeData(
-        fontFamily: 'NanumSquareRound',
-        textTheme: const TextTheme(
-          // 제목
-          headlineLarge: TextStyle(
-            fontSize: TextSizes.headline,
-            fontWeight: FontWeight.w800
-          ),
-          //
-
-
-          // 일반 본문
-          bodyLarge: TextStyle(
-            fontSize: TextSizes.body,
-            fontWeight: FontWeight.w700
-          ),
-
-          // 일반 본문
-          bodyMedium: TextStyle(
-            fontSize: TextSizes.body,
-            fontWeight: FontWeight.w400
-          ),
-
-          // 부가 설명용
-          bodySmall: TextStyle(
-            fontSize: TextSizes.caption,
-            fontWeight: FontWeight.w300
-          )
-
-
-
-        ),
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true
-      ),
-      home: HomeScreen()
-    );
-  }
 }
 

--- a/lib/ui/common/const/colors.dart
+++ b/lib/ui/common/const/colors.dart
@@ -1,10 +1,14 @@
 import 'dart:ui';
 
+
+// 사용 예시
+// style : ElevatedButton.styleFrom(backgroundColor: AppColors.btnPrimary )
+
 class AppColors {
-  static const Color primary = Color(0xFFA2D9EB); // 메인 색상
+  static const Color primary = Color(0xFF436476); // 메인 색상
+  static const Color secondary = Color(0xFFA2D9EB); // 서브 색상
   static const Color btnPrimary = Color(0xFF125287); // 버튼 메인 색상
   static const Color red = Color(0xFFF41F1F); // 빨강색
   static const Color green = Color(0xFF0FC537); // 초록색
   static const Color white = Color(0xFFFFFFFF); // 흰색
-
 }

--- a/lib/ui/main/bottom_nav_screen.dart
+++ b/lib/ui/main/bottom_nav_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:look_talk/ui/common/const/colors.dart';
+
+class BottomNavScreen extends StatelessWidget {
+  final Widget child;
+
+  const BottomNavScreen({super.key, required this.child});
+
+  int _calculateSelectedIndex(BuildContext context) {
+    final location = GoRouterState.of(context).uri.toString();
+    if (location.startsWith('/home')) return 0;
+    if (location.startsWith('/category')) return 1;
+    if (location.startsWith('/community')) return 2;
+    if (location.startsWith('/wishlist')) return 3;
+    if (location.startsWith('/mypage')) return 4;
+    return 0;
+  }
+
+  void _onTap(BuildContext context, int index) {
+    switch (index) {
+      case 0:
+        context.go('/home');
+        break;
+      case 1:
+        context.go('/category');
+        break;
+      case 2:
+        context.go('/community');
+        break;
+      case 3:
+        context.go('/wishlist');
+        break;
+      case 4:
+        context.go('/mypage');
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedIndex = _calculateSelectedIndex(context);
+
+    return Scaffold(
+      body: child,
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: selectedIndex,
+        onTap: (index) => _onTap(context, index),
+        type: BottomNavigationBarType.fixed,
+        selectedItemColor: AppColors.primary,
+        unselectedItemColor: Colors.grey,
+        selectedIconTheme: IconThemeData(size: 32),
+        unselectedIconTheme: IconThemeData(size: 26),
+        iconSize: 30,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home, ), label: '홈'),
+          BottomNavigationBarItem(icon: Icon(Icons.list, ), label: '카테고리'),
+          BottomNavigationBarItem(icon: Icon(Icons.forum, ), label: '커뮤니티'),
+          BottomNavigationBarItem(icon: Icon(Icons.favorite,), label: '찜'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: '마이페이지'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/main/category/category_screen.dart
+++ b/lib/ui/main/category/category_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class CategoryScreen extends StatelessWidget{
+  const CategoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('카테고리'),),
+      body: Center(child: Text('카테고리'),),
+    );
+  }
+}

--- a/lib/ui/main/community/community_screen.dart
+++ b/lib/ui/main/community/community_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class CommunityScreen extends StatelessWidget{
+  const CommunityScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('커뮤니티'),),
+      body: Center(child: Text('커뮤니티'),),
+    );
+  }
+}

--- a/lib/ui/main/home/home_screen.dart
+++ b/lib/ui/main/home/home_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:look_talk/core/extension/text_style_extension.dart';
 import 'package:look_talk/ui/common/common_modal.dart';
 
 class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -11,12 +14,12 @@ class HomeScreen extends StatelessWidget {
           children: [
             Text(
               '헤드라인 텍스트입니다',
-              style: Theme.of(context).textTheme.headlineLarge,
+              style: context.h1,
             ),
             const SizedBox(height: 8),
-            Text('본문 텍스트입니다', style: Theme.of(context).textTheme.bodyLarge),
+            Text('본문 텍스트입니다', style: context.body),
             const SizedBox(height: 8),
-            Text('설명 텍스트입니다', style: Theme.of(context).textTheme.bodySmall),
+            Text('설명 텍스트입니다', style: context.caption),
             const SizedBox(height: 8),
             ElevatedButton(
               onPressed: () {
@@ -32,7 +35,7 @@ class HomeScreen extends StatelessWidget {
                   ),
                 );
               },
-              child: Text('모달 열기'),
+              child: Text('모달 열기', style: context.body,),
             ),
           ],
         ),

--- a/lib/ui/main/mypage/mypage_screen.dart
+++ b/lib/ui/main/mypage/mypage_screen.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class MyPageScreen extends StatelessWidget{
+  const MyPageScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('마이페이지'),),
+      body: Center(child: Text('마이페이지'),),
+    );
+  }
+}

--- a/lib/ui/main/wishlist/wishlist_screen.dart
+++ b/lib/ui/main/wishlist/wishlist_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class WishlistScreen extends StatelessWidget{
+  const WishlistScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('찜'),),
+      body: Center(child: Text('찜한 상품 목록'),),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: ac294be30ba841830cfa146e5a3b22bb09f8dc5a0fdd9ca9332b04b0bde99ebf
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.2.4"
   leak_tracker:
     dependency: transitive
     description:
@@ -107,6 +120,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -210,4 +231,4 @@ packages:
     version: "15.0.0"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  go_router: ^15.2.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 변경 내용 요약
- router.dart에서 GoRouter와 ShellRoute를 사용해 Bottom Navigation 탭(Home, Category, Community, Wishlist, MyPage)을 라우팅 구성
- bottom_nav_screen.dart에서 현재 라우트 위치에 따라 선택된 탭을 반영하고, 탭 클릭 시 해당 경로로 이동하는 BottomNavigationBar 구현

## 테스트 방법
- 네이베이션 바 클릭해보며 정상 작동하는지 확인

## 체크리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인