### PR TITLE
Fix: common text field에서 height 삭제

### DIFF
--- a/lib/ui/common/component/common_text_field.dart
+++ b/lib/ui/common/component/common_text_field.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 // 아래와 같이 사용하면 기본 값으로 되고 hintText, 높이, 너비 등 추가 설정 가능합니다!
 // CommonTextField()
 
+// 높이는 maxLines 로 조정하시면 됩니다!
 
 class CommonTextField extends StatelessWidget {
   final String? hintText;
@@ -15,7 +16,6 @@ class CommonTextField extends StatelessWidget {
   final EdgeInsetsGeometry contentPadding;
   final FocusNode? focusNode;
   final double? width;
-  final double? height;
 
   const CommonTextField({
     super.key,
@@ -28,14 +28,12 @@ class CommonTextField extends StatelessWidget {
     this.contentPadding = const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
     this.focusNode,
     this.width,
-    this.height,
   });
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
       width: width ?? double.infinity,
-      height: height, // null 이면 자동 높이
       child: TextFormField(
         controller: controller,
         obscureText: obscureText,


### PR DESCRIPTION
## 변경 내용 요약
-헷갈리실 것 같아서 common text field에서 height 삭제했습니다! 높이 조절은 maxLines로 해주시면 됩니다! 

## 테스트 방법
- 게시글 등록 화면 만들면서 테스트 했습니다! 

## 체크리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인